### PR TITLE
Test optimization

### DIFF
--- a/lib/__test__/index.test.js
+++ b/lib/__test__/index.test.js
@@ -39,8 +39,7 @@ describe('Cluster Harakiri', () => {
       const url = `http://localhost:${process.env.TEST_PORT}`;
       const ids = Object.keys(cluster.workers).map(Number);
 
-      cluster.on('exit', (worker) => {
-        cluster.removeAllListeners('exit');
+      cluster.once('exit', (worker) => {
         expect(ids.includes(worker.id)).toBeTruthy();
         done();
       });
@@ -60,8 +59,7 @@ describe('Cluster Harakiri', () => {
     waitForWorkers(() => {
       const ids = Object.keys(cluster.workers).map(Number);
 
-      cluster.on('exit', (worker) => {
-        cluster.removeAllListeners('exit');
+      cluster.once('exit', (worker) => {
         expect(ids.includes(worker.id)).toBeTruthy();
         done();
       });


### PR DESCRIPTION
Closes #3 

Uses `once` to better handle only one event