### PR TITLE
Allow for configuring harakiri

### DIFF
--- a/lib/__test__/index.test.js
+++ b/lib/__test__/index.test.js
@@ -1,66 +1,93 @@
-const http = require('http');
 const path = require('path');
-const cluster = require('..');
+const axios = require('axios');
 
 const WORKER_COUNT = 4;
 
-cluster.setupPrimary({
-  exec: path.join(__dirname, 'stub.js'),
+const waitForWorkerStart = (_cluster, test) => {
+  let workersOnline = 0;
+  _cluster.on('online', () => {
+    workersOnline += 1;
+    if (workersOnline === WORKER_COUNT) {
+      test();
+    }
+  });
+};
+
+const waitForWorkerEnd = (_cluster, ids, done) => {
+  _cluster.on('exit', (worker) => {
+    expect(ids.includes(worker.id)).toBeTruthy();
+    /* eslint-disable-next-line no-param-reassign */
+    ids = ids.filter((id) => id !== worker.id);
+    if (ids.length === 0) {
+      _cluster.removeAllListeners('exit');
+      done();
+    }
+  });
+};
+
+let cluster;
+
+beforeEach(() => {
+  jest.resetModules();
+  /* eslint-disable-next-line global-require */
+  cluster = require('..');
+  cluster.setupPrimary({
+    exec: path.join(__dirname, 'stub.js'),
+  });
+
+  jest
+    .useFakeTimers()
+    .setSystemTime(new Date('2022-01-01T12:00:00'));
 });
 
-describe('Cluster Harakiri', () => {
+afterEach(() => {
+  jest.useRealTimers();
+
+  for (const id in cluster.workers) {
+    if (Object.prototype.hasOwnProperty.call(cluster.workers, id)) {
+      cluster.workers[id].process.kill();
+    }
+  }
+});
+
+describe('Cluster Harakiri (env)', () => {
   beforeEach(() => {
+    cluster.setupHarakiri({ restartWorker: false });
     for (let i = 0; i < WORKER_COUNT; i++) {
       cluster.fork();
     }
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-    for (const id in cluster.workers) {
-      if (Object.prototype.hasOwnProperty.call(cluster.workers, id)) {
-        cluster.workers[id].process.kill();
-      }
-    }
-  });
-
-  const waitForWorkers = (test) => {
-    let workersOnline = 0;
-    cluster.on('online', () => {
-      workersOnline += 1;
-      if (workersOnline === WORKER_COUNT) {
-        test();
-      }
-    });
-  };
-
   test('terminates workers after limit', (done) => {
-    waitForWorkers(() => {
+    let complete = false;
+
+    waitForWorkerStart(cluster, async () => {
       const url = `http://localhost:${process.env.TEST_PORT}`;
       const ids = Object.keys(cluster.workers).map(Number);
 
-      cluster.once('exit', (worker) => {
-        expect(ids.includes(worker.id)).toBeTruthy();
+      waitForWorkerEnd(cluster, ids, () => {
+        expect(complete).toBeTruthy();
         done();
       });
 
       const maxConnections = process.env.HARAKIRI_WORKER_CONN_LIMIT * WORKER_COUNT;
-      for (let i = 0; i < maxConnections + 1; i++) {
-        http.get(url);
+      for (let i = 0; i < maxConnections + WORKER_COUNT; i++) {
+        /* eslint-disable-next-line no-await-in-loop */
+        await axios.get(url);
       }
+
+      complete = true;
     });
   });
 
   test('terminates workers after time', (done) => {
-    jest
-      .useFakeTimers()
-      .setSystemTime(new Date('2022-01-01T12:00:00'));
+    let complete = false;
 
-    waitForWorkers(() => {
+    waitForWorkerStart(cluster, () => {
       const ids = Object.keys(cluster.workers).map(Number);
 
-      cluster.once('exit', (worker) => {
-        expect(ids.includes(worker.id)).toBeTruthy();
+      waitForWorkerEnd(cluster, ids, () => {
+        expect(complete).toBeTruthy();
         done();
       });
 
@@ -69,8 +96,71 @@ describe('Cluster Harakiri', () => {
       const newIds = Object.keys(cluster.workers).map(Number);
       expect(ids.every((element, index) => element === newIds[index]));
 
+      complete = true;
       jest.setSystemTime(new Date('2022-01-01T12:00:30'));
       jest.advanceTimersByTime(process.env.HARAKIRI_WORKER_TTL / 2);
+    });
+  });
+});
+
+describe('Cluster Harakiri (conf)', () => {
+  const ttl = 60000;
+  const connectionLimit = 1;
+
+  beforeEach(() => {
+    cluster.setupHarakiri({ ttl, connectionLimit, restartWorker: false });
+    for (let i = 0; i < WORKER_COUNT; i++) {
+      cluster.fork();
+    }
+  });
+
+  test('terminates workers after limit', (done) => {
+    let complete = false;
+
+    waitForWorkerStart(cluster, async () => {
+      const url = `http://localhost:${process.env.TEST_PORT}`;
+      const ids = Object.keys(cluster.workers).map(Number);
+
+      waitForWorkerEnd(cluster, ids, () => {
+        expect(complete).toBeTruthy();
+        done();
+      });
+
+      const maxConnections = connectionLimit * WORKER_COUNT;
+      for (let i = 0; i < maxConnections + WORKER_COUNT; i++) {
+        /* eslint-disable-next-line no-await-in-loop */
+        await axios.get(url);
+      }
+
+      complete = true;
+    });
+  });
+
+  test('terminates workers after time', (done) => {
+    let complete = false;
+
+    waitForWorkerStart(cluster, () => {
+      const ids = Object.keys(cluster.workers).map(Number);
+
+      waitForWorkerEnd(cluster, ids, () => {
+        expect(complete).toBeTruthy();
+        done();
+      });
+
+      jest.advanceTimersByTime(process.env.HARAKIRI_WORKER_TTL / 2);
+
+      let newIds = Object.keys(cluster.workers).map(Number);
+      expect(ids.every((element, index) => element === newIds[index]));
+
+      jest.setSystemTime(new Date('2022-01-01T12:00:30'));
+      jest.advanceTimersByTime(process.env.HARAKIRI_WORKER_TTL / 2);
+
+      newIds = Object.keys(cluster.workers).map(Number);
+      expect(ids.every((element, index) => element === newIds[index]));
+
+      complete = true;
+      jest.setSystemTime(new Date('2022-01-01T12:01:00'));
+      jest.advanceTimersByTime(ttl);
     });
   });
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,43 +5,64 @@ const WORKER_CONN_LIMIT = parseInt(process.env.HARAKIRI_WORKER_CONN_LIMIT, 10);
 const WORKER_TTL = parseInt(process.env.HARAKIRI_WORKER_TTL, 10);
 
 const workers = {};
+let initialized = false;
 
-const terminateWorker = (id) => {
-  cluster.workers[id].disconnect();
-  delete workers[id];
-  debug(workers);
-  cluster.fork();
-};
+const setupHarakiri = (options) => {
+  const ttl = (options && options.ttl) || WORKER_TTL;
+  const connectionLimit = (options && options.connectionLimit) || WORKER_CONN_LIMIT;
+  const restartWorker = !(options && options.restartWorker === false);
 
-if (WORKER_TTL) {
-  setInterval(() => {
-    for (const id in workers) {
-      if ((Date.now() - workers[id].startTime) > WORKER_TTL) {
-        debug(`Terminating worker ${id} due to age`);
-        terminateWorker(id);
-      }
+  const terminateWorker = (id) => {
+    cluster.workers[id].disconnect();
+    delete workers[id];
+    debug(workers);
+    if (restartWorker) {
+      cluster.fork();
     }
-  }, WORKER_TTL / 10);
-}
-
-cluster.on('online', (worker) => {
-  workers[worker.id] = {
-    startTime: Date.now(),
-    connectionCount: 0,
   };
-  debug(workers);
 
-  if (WORKER_CONN_LIMIT) {
-    worker.process.on('internalMessage', (message) => {
-      if (message.cmd === 'NODE_CLUSTER' && message.accepted) {
-        workers[worker.id].connectionCount += 1;
-        if (workers[worker.id].connectionCount > WORKER_CONN_LIMIT) {
-          debug(`Terminating worker ${worker.id} due to connection limit`);
-          terminateWorker(worker.id);
+  if (initialized) {
+    return;
+  }
+
+  initialized = true;
+  if (ttl) {
+    setInterval(() => {
+      for (const id in workers) {
+        if ((Date.now() - workers[id].startTime) > ttl) {
+          debug(`Terminating worker ${id} due to age`);
+          terminateWorker(id);
         }
       }
-    });
+    }, ttl / 10);
   }
-});
+
+  cluster.on('online', (worker) => {
+    workers[worker.id] = {
+      startTime: Date.now(),
+      connectionCount: 0,
+    };
+    debug(workers);
+
+    if (connectionLimit) {
+      worker.process.on('internalMessage', (message) => {
+        if (message.cmd === 'NODE_CLUSTER' && message.accepted) {
+          workers[worker.id].connectionCount += 1;
+          if (workers[worker.id].connectionCount > connectionLimit) {
+            debug(`Terminating worker ${worker.id} due to connection limit`);
+            terminateWorker(worker.id);
+          }
+        }
+      });
+    }
+  });
+};
+
+const clusterFork = cluster.fork;
+cluster.fork = (env) => {
+  setupHarakiri();
+  return clusterFork(env);
+};
+cluster.setupHarakiri = setupHarakiri;
 
 module.exports = cluster;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "debug": "^4.3.4"
       },
       "devDependencies": {
+        "axios": "^0.27.2",
         "eslint": "^8.23.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-friendly-formatter": "^4.0.1",
@@ -1446,6 +1447,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.0.2",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.0.2.tgz",
@@ -1743,6 +1760,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1835,6 +1864,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -2672,6 +2710,40 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -4110,6 +4182,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -6387,6 +6480,22 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "babel-jest": {
       "version": "29.0.2",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.0.2.tgz",
@@ -6609,6 +6718,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6684,6 +6802,12 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -7331,6 +7455,23 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "dev": true
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -8385,6 +8526,21 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Controls creation and removal of workers at a regular interval",
   "main": "index.js",
   "scripts": {
-    "test": "TEST_PORT=12345 HARAKIRI_WORKER_CONN_LIMIT=2 HARAKIRI_WORKER_TTL=30000 jest --forceExit --silent --coverage --color",
+    "test": "TEST_PORT=12345 HARAKIRI_WORKER_CONN_LIMIT=2 HARAKIRI_WORKER_TTL=30000 jest --silent --coverage --color",
     "lint": "eslint --format node_modules/eslint-friendly-formatter .",
     "lint:fix": "eslint --fix --format node_modules/eslint-friendly-formatter ."
   },
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/smartfile/node-cluster-harakiri#readme",
   "devDependencies": {
+    "axios": "^0.27.2",
     "eslint": "^8.23.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-friendly-formatter": "^4.0.1",


### PR DESCRIPTION
Closes #4 

Adds `setupHarakiri` to allow optional configuration outside of the environment. Options are `connectionLimit`, `ttl`, and `restartWorkers`. The tests are updated to use `restartWorkers` to prevent new workers from spawning. This allows for better assertions and to confirm that all workers end before starting the next test. This also fixed the issue causing `forceExit` to be used in `jest`.