### PR TITLE
Check connection limit periodically

### DIFF
--- a/lib/__test__/index.test.js
+++ b/lib/__test__/index.test.js
@@ -92,24 +92,31 @@ describe('Cluster Harakiri (env)', () => {
         done();
       });
 
-      jest.advanceTimersByTime(process.env.HARAKIRI_WORKER_TTL / 2);
+      jest.setSystemTime(new Date('2022-01-01T12:00:10'));
+      jest.advanceTimersToNextTimer();
 
       const newIds = Object.keys(cluster.workers).map(Number);
       expect(ids.every((element, index) => element === newIds[index]));
 
       complete = true;
       jest.setSystemTime(new Date('2022-01-01T12:00:30'));
-      jest.advanceTimersByTime(process.env.HARAKIRI_WORKER_TTL / 2);
+      jest.advanceTimersToNextTimer();
     });
   });
 });
 
 describe('Cluster Harakiri (conf)', () => {
   const ttl = 60000;
+  const checkInterval = 20000;
   const connectionLimit = 1;
 
   beforeEach(() => {
-    cluster.setupHarakiri({ ttl, connectionLimit, restartWorker: false });
+    cluster.setupHarakiri({
+      ttl,
+      checkInterval,
+      connectionLimit,
+      restartWorker: false,
+    });
     for (let i = 0; i < WORKER_COUNT; i++) {
       cluster.fork();
     }
@@ -149,20 +156,21 @@ describe('Cluster Harakiri (conf)', () => {
         done();
       });
 
-      jest.advanceTimersByTime(process.env.HARAKIRI_WORKER_TTL / 2);
+      jest.setSystemTime(new Date('2022-01-01T12:00:20'));
+      jest.advanceTimersToNextTimer();
 
       let newIds = Object.keys(cluster.workers).map(Number);
       expect(ids.every((element, index) => element === newIds[index]));
 
-      jest.setSystemTime(new Date('2022-01-01T12:00:30'));
-      jest.advanceTimersByTime(process.env.HARAKIRI_WORKER_TTL / 2);
+      jest.setSystemTime(new Date('2022-01-01T12:00:40'));
+      jest.advanceTimersToNextTimer();
 
       newIds = Object.keys(cluster.workers).map(Number);
       expect(ids.every((element, index) => element === newIds[index]));
 
       complete = true;
       jest.setSystemTime(new Date('2022-01-01T12:01:00'));
-      jest.advanceTimersByTime(ttl);
+      jest.advanceTimersToNextTimer();
     });
   });
 });

--- a/lib/__test__/index.test.js
+++ b/lib/__test__/index.test.js
@@ -71,10 +71,11 @@ describe('Cluster Harakiri (env)', () => {
       });
 
       const maxConnections = process.env.HARAKIRI_WORKER_CONN_LIMIT * WORKER_COUNT;
-      for (let i = 0; i < maxConnections + WORKER_COUNT; i++) {
+      for (let i = 0; i < maxConnections + (2 * WORKER_COUNT); i++) {
         /* eslint-disable-next-line no-await-in-loop */
         await axios.get(url);
       }
+      jest.advanceTimersToNextTimer();
 
       complete = true;
     });
@@ -127,10 +128,11 @@ describe('Cluster Harakiri (conf)', () => {
       });
 
       const maxConnections = connectionLimit * WORKER_COUNT;
-      for (let i = 0; i < maxConnections + WORKER_COUNT; i++) {
+      for (let i = 0; i < maxConnections + (2 * WORKER_COUNT); i++) {
         /* eslint-disable-next-line no-await-in-loop */
         await axios.get(url);
       }
+      jest.advanceTimersToNextTimer();
 
       complete = true;
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,16 +26,18 @@ const setupHarakiri = (options) => {
   }
 
   initialized = true;
-  if (ttl) {
-    setInterval(() => {
-      for (const id in workers) {
-        if ((Date.now() - workers[id].startTime) > ttl) {
-          debug(`Terminating worker ${id} due to age`);
-          terminateWorker(id);
-        }
+  setInterval(() => {
+    debug(workers);
+    for (const id in workers) {
+      if (ttl && (Date.now() - workers[id].startTime) > ttl) {
+        debug(`Terminating worker ${id} due to age`);
+        terminateWorker(id);
+      } else if (connectionLimit && workers[id].connectionCount > connectionLimit) {
+        debug(`Terminating worker ${id} due to connection limit`);
+        terminateWorker(id);
       }
-    }, ttl / 10);
-  }
+    }
+  }, (ttl || 10000) / 10);
 
   cluster.on('online', (worker) => {
     workers[worker.id] = {
@@ -48,10 +50,6 @@ const setupHarakiri = (options) => {
       worker.process.on('internalMessage', (message) => {
         if (message.cmd === 'NODE_CLUSTER' && message.accepted) {
           workers[worker.id].connectionCount += 1;
-          if (workers[worker.id].connectionCount > connectionLimit) {
-            debug(`Terminating worker ${worker.id} due to connection limit`);
-            terminateWorker(worker.id);
-          }
         }
       });
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const debug = require('debug')('cluster-harakiri');
 
 const WORKER_CONN_LIMIT = parseInt(process.env.HARAKIRI_WORKER_CONN_LIMIT, 10);
 const WORKER_TTL = parseInt(process.env.HARAKIRI_WORKER_TTL, 10);
+const WORKER_CHECK_INTERVAL = parseInt(process.env.HARAKIRI_WORKER_CHECK_INTERVAL, 10) || 30000;
 
 const workers = {};
 let initialized = false;
@@ -11,6 +12,7 @@ const setupHarakiri = (options) => {
   const ttl = (options && options.ttl) || WORKER_TTL;
   const connectionLimit = (options && options.connectionLimit) || WORKER_CONN_LIMIT;
   const restartWorker = !(options && options.restartWorker === false);
+  const checkInterval = (options && options.checkInterval) || WORKER_CHECK_INTERVAL;
 
   const terminateWorker = (id) => {
     cluster.workers[id].disconnect();
@@ -26,6 +28,8 @@ const setupHarakiri = (options) => {
   }
 
   initialized = true;
+
+  const interval = (ttl) ? Math.min(ttl, checkInterval) : checkInterval;
   setInterval(() => {
     debug(workers);
     for (const id in workers) {
@@ -37,7 +41,7 @@ const setupHarakiri = (options) => {
         terminateWorker(id);
       }
     }
-  }, (ttl || 10000) / 10);
+  }, interval);
 
   cluster.on('online', (worker) => {
     workers[worker.id] = {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Controls creation and removal of workers at a regular interval",
   "main": "index.js",
   "scripts": {
-    "test": "TEST_PORT=12345 HARAKIRI_WORKER_CONN_LIMIT=2 HARAKIRI_WORKER_TTL=30000 jest --silent --coverage --color",
+    "test": "TEST_PORT=12345 HARAKIRI_WORKER_CONN_LIMIT=2 HARAKIRI_WORKER_TTL=30000 HARAKIRI_WORKER_CHECK_INTERVAL=10000 jest --silent --coverage --color",
     "lint": "eslint --format node_modules/eslint-friendly-formatter .",
     "lint:fix": "eslint --fix --format node_modules/eslint-friendly-formatter ."
   },


### PR DESCRIPTION
Closes #2 

Checks the connection limit periodically. If no ttl has been specified, uses a 1 second interval. The cluster module does not seem to do a perfect round robin or a worker is busy intermittently during the tests. This causes one worker to not have reached the limit to terminate. By doing an additional `WORKER_COUNT` of requests, all of the workers reach the limit consistently.