### PR TITLE
Add a delay between termination of workers

### DIFF
--- a/lib/__test__/index.test.js
+++ b/lib/__test__/index.test.js
@@ -28,16 +28,16 @@ const waitForWorkerEnd = (_cluster, ids, done) => {
 let cluster;
 
 beforeEach(() => {
+  jest
+    .useFakeTimers()
+    .setSystemTime(new Date('2022-01-01T12:00:00'));
+
   jest.resetModules();
   /* eslint-disable-next-line global-require */
   cluster = require('..');
   cluster.setupPrimary({
     exec: path.join(__dirname, 'stub.js'),
   });
-
-  jest
-    .useFakeTimers()
-    .setSystemTime(new Date('2022-01-01T12:00:00'));
 });
 
 afterEach(() => {
@@ -171,6 +171,86 @@ describe('Cluster Harakiri (conf)', () => {
       complete = true;
       jest.setSystemTime(new Date('2022-01-01T12:01:00'));
       jest.advanceTimersToNextTimer();
+    });
+  });
+});
+
+describe('Cluster Harakiri (delay)', () => {
+  const termDelay = 5000;
+
+  beforeEach(() => {
+    cluster.setupHarakiri({
+      termDelay,
+      restartWorker: false,
+    });
+    for (let i = 0; i < WORKER_COUNT; i++) {
+      cluster.fork();
+    }
+  });
+
+  test('terminates workers after limit', (done) => {
+    let complete = false;
+
+    waitForWorkerStart(cluster, async () => {
+      const url = `http://localhost:${process.env.TEST_PORT}`;
+      const ids = Object.keys(cluster.workers).map(Number);
+
+      waitForWorkerEnd(cluster, ids, () => {
+        expect(complete).toBeTruthy();
+        done();
+      });
+
+      const maxConnections = process.env.HARAKIRI_WORKER_CONN_LIMIT * WORKER_COUNT;
+      for (let i = 0; i < maxConnections + (2 * WORKER_COUNT); i++) {
+        /* eslint-disable-next-line no-await-in-loop */
+        await axios.get(url);
+      }
+
+      jest.advanceTimersToNextTimer();
+
+      jest.setSystemTime(new Date('2022-01-01T12:00:10'));
+      jest.advanceTimersToNextTimer();
+
+      jest.setSystemTime(new Date('2022-01-01T12:00:20'));
+      jest.advanceTimersToNextTimer();
+
+      jest.setSystemTime(new Date('2022-01-01T12:00:30'));
+      jest.advanceTimersToNextTimer();
+
+      jest.setSystemTime(new Date('2022-01-01T12:00:40'));
+      jest.advanceTimersToNextTimer();
+
+      complete = true;
+    });
+  });
+
+  test('terminates workers after time', (done) => {
+    let complete = false;
+
+    waitForWorkerStart(cluster, () => {
+      const ids = Object.keys(cluster.workers).map(Number);
+
+      waitForWorkerEnd(cluster, ids, () => {
+        expect(complete).toBeTruthy();
+        done();
+      });
+
+      jest.setSystemTime(new Date('2022-01-01T12:00:30'));
+      jest.advanceTimersToNextTimer();
+
+      jest.setSystemTime(new Date('2022-01-01T12:00:40'));
+      jest.advanceTimersToNextTimer();
+
+      jest.setSystemTime(new Date('2022-01-01T12:00:50'));
+      jest.advanceTimersToNextTimer();
+
+      jest.setSystemTime(new Date('2022-01-01T12:01:00'));
+      jest.advanceTimersToNextTimer();
+
+      jest.setSystemTime(new Date('2022-01-01T12:01:10'));
+      jest.advanceTimersToNextTimer();
+
+      complete = true;
     });
   });
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,11 @@ const debug = require('debug')('cluster-harakiri');
 const WORKER_CONN_LIMIT = parseInt(process.env.HARAKIRI_WORKER_CONN_LIMIT, 10);
 const WORKER_TTL = parseInt(process.env.HARAKIRI_WORKER_TTL, 10);
 const WORKER_CHECK_INTERVAL = parseInt(process.env.HARAKIRI_WORKER_CHECK_INTERVAL, 10) || 30000;
+const WORKER_TERM_DELAY = parseInt(process.env.HARAKIRI_WORKER_TERM_DELAY, 10);
 
 const workers = {};
+const terminatingWorkers = [];
+let lastTermination = Date.now();
 let initialized = false;
 
 const setupHarakiri = (options) => {
@@ -13,13 +16,23 @@ const setupHarakiri = (options) => {
   const connectionLimit = (options && options.connectionLimit) || WORKER_CONN_LIMIT;
   const restartWorker = !(options && options.restartWorker === false);
   const checkInterval = (options && options.checkInterval) || WORKER_CHECK_INTERVAL;
+  const termDelay = (options && options.termDelay) || WORKER_TERM_DELAY;
 
   const terminateWorker = (id) => {
+    lastTermination = Date.now();
     cluster.workers[id].disconnect();
-    delete workers[id];
-    debug(workers);
     if (restartWorker) {
       cluster.fork();
+    }
+  };
+
+  const queueTermination = (id) => {
+    delete workers[id];
+    debug(workers);
+    if (termDelay) {
+      terminatingWorkers.push(id);
+    } else {
+      terminateWorker(id);
     }
   };
 
@@ -35,10 +48,15 @@ const setupHarakiri = (options) => {
     for (const id in workers) {
       if (ttl && (Date.now() - workers[id].startTime) > ttl) {
         debug(`Terminating worker ${id} due to age`);
-        terminateWorker(id);
+        queueTermination(id);
       } else if (connectionLimit && workers[id].connectionCount > connectionLimit) {
         debug(`Terminating worker ${id} due to connection limit`);
-        terminateWorker(id);
+        queueTermination(id);
+      }
+    }
+    if (termDelay && terminatingWorkers.length > 0) {
+      if (Date.now() - lastTermination > termDelay) {
+        terminateWorker(terminatingWorkers.shift());
       }
     }
   }, interval);


### PR DESCRIPTION
Closes #1 

Adds a configurable delay between terminations of workers. This prevents the possibility of many or all of the workers being down at the same time