### PR TITLE
Add timeout to kill lingering workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ The periodic interval, in seconds, to check if there are any workers to terminat
 If present, the amount of time to delay, in seconds, between terminating workers. This can be used to prevent
 many or all workers from being terminated at the same time.
 
+`closeTimeout`
+
+| Type | Default value | Environmental variable
+| --- | --- | --- |
+| number | | `HARAKIRI_WORKER_CLOSE_TIMEOUT`
+
+If present, the amount of time, in seconds, to wait for the worker to exit after termination. This can
+be used to prevent a worker from running indefinitely if the connection stays alive.
+
 `restartWorker`
 
 | Type | Default value | Environmental variable

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ const setupHarakiri = (options) => {
         terminateWorker(terminatingWorkers.shift());
       }
     }
-    if (closeTimeout && Object.keys(closingWorkers).length > 0) {
+    if (closeTimeout) {
       for (const id in closingWorkers) {
         if (Date.now() - closingWorkers[id].terminationTime > closeTimeout) {
           debug(`Force killing worker ${id}`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,9 +5,11 @@ const WORKER_CONN_LIMIT = parseInt(process.env.HARAKIRI_WORKER_CONN_LIMIT, 10);
 const WORKER_TTL = parseInt(process.env.HARAKIRI_WORKER_TTL, 10);
 const WORKER_CHECK_INTERVAL = parseInt(process.env.HARAKIRI_WORKER_CHECK_INTERVAL, 10) || 30;
 const WORKER_TERM_DELAY = parseInt(process.env.HARAKIRI_WORKER_TERM_DELAY, 10);
+const WORKER_CLOSE_TIMEOUT = parseInt(process.env.HARAKIRI_WORKER_CLOSE_TIMEOUT, 10);
 
 const workers = {};
 const terminatingWorkers = [];
+const closingWorkers = {};
 let lastTermination = Date.now();
 let initialized = false;
 
@@ -17,9 +19,16 @@ const setupHarakiri = (options) => {
   const restartWorker = !(options && options.restartWorker === false);
   const checkInterval = ((options && options.checkInterval) || WORKER_CHECK_INTERVAL) * 1000;
   const termDelay = ((options && options.termDelay) || WORKER_TERM_DELAY) * 1000;
+  const closeTimeout = ((options && options.closeTimeout) || WORKER_CLOSE_TIMEOUT) * 1000;
 
   const terminateWorker = (id) => {
     lastTermination = Date.now();
+    if (closeTimeout) {
+      closingWorkers[id] = {
+        terminationTime: Date.now(),
+        worker: cluster.workers[id],
+      };
+    }
     cluster.workers[id].disconnect();
     if (restartWorker) {
       cluster.fork();
@@ -59,6 +68,14 @@ const setupHarakiri = (options) => {
         terminateWorker(terminatingWorkers.shift());
       }
     }
+    if (closeTimeout && Object.keys(closingWorkers).length > 0) {
+      for (const id in closingWorkers) {
+        if (Date.now() - closingWorkers[id].terminationTime > closeTimeout) {
+          debug(`Force killing worker ${id}`);
+          closingWorkers[id].worker.kill();
+        }
+      }
+    }
   }, interval);
 
   cluster.on('online', (worker) => {
@@ -76,6 +93,14 @@ const setupHarakiri = (options) => {
       });
     }
   });
+
+  if (closeTimeout) {
+    cluster.on('exit', (worker) => {
+      if (worker.id in closingWorkers) {
+        delete closingWorkers[worker.id];
+      }
+    });
+  }
 };
 
 const clusterFork = cluster.fork;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Controls creation and removal of workers at a regular interval",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "TEST_PORT=12345 HARAKIRI_WORKER_CONN_LIMIT=2 HARAKIRI_WORKER_TTL=30 HARAKIRI_WORKER_CHECK_INTERVAL=10 jest --silent --coverage --color",
+    "test": "TEST_PORT=12345 HARAKIRI_WORKER_CONN_LIMIT=2 HARAKIRI_WORKER_TTL=30 HARAKIRI_WORKER_CHECK_INTERVAL=10 HARAKIRI_WORKER_CLOSE_TIMEOUT=3600 jest --silent --coverage --color",
     "lint": "eslint --format node_modules/eslint-friendly-formatter .",
     "lint:fix": "eslint --fix --format node_modules/eslint-friendly-formatter ."
   },


### PR DESCRIPTION
Adds a configurable timeout to wait after a worker has been disconnected for that worker to exit. This can be used to ultimately force the worker to exit if something is keeping the connection alive.