### PR TITLE
Cleanup lists

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,13 +94,17 @@ const setupHarakiri = (options) => {
     }
   });
 
-  if (closeTimeout) {
-    cluster.on('exit', (worker) => {
-      if (worker.id in closingWorkers) {
-        delete closingWorkers[worker.id];
-      }
-    });
-  }
+  cluster.on('exit', (worker) => {
+    if (terminatingWorkers.includes(worker.id)) {
+      terminatingWorkers.splice(terminatingWorkers.indexOf(worker.id), 1);
+    }
+    if (worker.id in workers) {
+      delete workers[worker.id];
+    }
+    if (worker.id in closingWorkers) {
+      delete closingWorkers[worker.id];
+    }
+  });
 };
 
 const clusterFork = cluster.fork;

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,7 @@ const setupHarakiri = (options) => {
 
     if (connectionLimit) {
       worker.process.on('internalMessage', (message) => {
-        if (message.cmd === 'NODE_CLUSTER' && message.accepted) {
+        if (message.cmd === 'NODE_CLUSTER' && message.accepted && worker.id in workers) {
           workers[worker.id].connectionCount += 1;
         }
       });


### PR DESCRIPTION
If a worker exits, check if it is in any list and remove it. This can happen if there is some unexpected exit such as an unhandled exception. At that point, it is no longer running, so it will eventually fail when the library attempts to `disconnect`: https://sentry.lumanox.io/organizations/lumanox/issues/45835/