### PR TITLE
Worker restart on exit

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,6 +95,11 @@ const setupHarakiri = (options) => {
   });
 
   cluster.on('exit', (worker) => {
+    if (!worker.exitedAfterDisconnect) {
+      // Something unexpected happened. A new worker needs to be created.
+      cluster.fork();
+    }
+
     if (terminatingWorkers.includes(worker.id)) {
       terminatingWorkers.splice(terminatingWorkers.indexOf(worker.id), 1);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,9 +30,6 @@ const setupHarakiri = (options) => {
       };
     }
     cluster.workers[id].disconnect();
-    if (restartWorker) {
-      cluster.fork();
-    }
   };
 
   const queueTermination = (id) => {
@@ -103,6 +100,9 @@ const setupHarakiri = (options) => {
     }
     if (worker.id in closingWorkers) {
       delete closingWorkers[worker.id];
+    }
+    if (restartWorker) {
+      cluster.fork();
     }
   });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,9 @@ const setupHarakiri = (options) => {
       };
     }
     cluster.workers[id].disconnect();
+    if (restartWorker) {
+      cluster.fork();
+    }
   };
 
   const queueTermination = (id) => {
@@ -100,9 +103,6 @@ const setupHarakiri = (options) => {
     }
     if (worker.id in closingWorkers) {
       delete closingWorkers[worker.id];
-    }
-    if (restartWorker) {
-      cluster.fork();
     }
   });
 };


### PR DESCRIPTION
Re-create the worker on unexpected exit. Otherwise, the workers will never be at the desired count again.